### PR TITLE
2.3 string passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+DSFMLC
+=======
+[![Build Status](https://travis-ci.org/Jebbs/DSFMLC.svg?branch=master)](https://travis-ci.org/Jebbs/DSFMLC) [![Build status](https://ci.appveyor.com/api/projects/status/33wb291gyvobq447/branch/master?svg=true)](https://ci.appveyor.com/project/Jebbs/dsfmlc/branch/master)
+
+DSFMLC is a C/C++ library based off of CSFML to allow DSFML the ablility to interact with and use the SFML library.
+
+The purpose of DSFMLC is to be a better link between DSFML and SFML than CSFML was, and also fixes some issues encountered wtih CSFML, namely [this](http://d.puremagic.com/issues/show_bug.cgi?id=5570) issue.
+
+
+Building DSFMLC
+=======
+DSFML uses the shared libraries produced by DSFMLC, so you need to build them in order use DSFML.
+For prebuilt binaries you can use [these](http://jebbs.github.io/DSFML/downloads.html).  
+
+To build from source, you can go [here](http://dsfml.com/docs/buildingfromsource.html) or follow [SFML's tutorial](http://www.sfml-dev.org/tutorials/2.1/compile-with-cmake.php).
+
+Other thoughts
+=======
+Feel free to open up some issues in the tracker! The backend doesn't see as much love as the front end.

--- a/include/DSFML/Audio/InputSoundFile.h
+++ b/include/DSFML/Audio/InputSoundFile.h
@@ -35,6 +35,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Audio/Export.h>
 #include <DSFML/Audio/Types.h>
 #include <DSFML/System/DStream.hpp>
+#include <stddef.h>
 
 //Creates the sound file
 DSFML_AUDIO_API sfInputSoundFile* sfInputSoundFile_create();
@@ -52,7 +53,7 @@ DSFML_AUDIO_API DUint sfInputSoundFile_getChannelCount( const sfInputSoundFile* 
 DSFML_AUDIO_API DUint sfInputSoundFile_getSampleRate(const sfInputSoundFile* file);
 
 //Open a sound file for reading
-DSFML_AUDIO_API DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file, const char* filename);
+DSFML_AUDIO_API DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file, const char* filename, size_t length);
 
 //Open a sound file in memory for reading
 DSFML_AUDIO_API DBool sfInputSoundFile_openFromMemory(sfInputSoundFile* file,void* data, DLong sizeInBytes);

--- a/include/DSFML/Audio/OutputSoundFile.h
+++ b/include/DSFML/Audio/OutputSoundFile.h
@@ -34,6 +34,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 //Headers
 #include <DSFML/Audio/Export.h>
 #include <DSFML/Audio/Types.h>
+#include <stddef.h>
 
 //Creates the sound file
 DSFML_AUDIO_API sfOutputSoundFile* sfOutputSoundFile_create();
@@ -42,7 +43,7 @@ DSFML_AUDIO_API sfOutputSoundFile* sfOutputSoundFile_create();
 DSFML_AUDIO_API void sfOutputSoundFile_destroy(sfOutputSoundFile* file);
 
 //Open a sound file for writting
-DSFML_AUDIO_API DBool sfOutputSoundFile_openFromFile(sfOutputSoundFile* file, const char* filename,DUint channelCount,DUint sampleRate);
+DSFML_AUDIO_API DBool sfOutputSoundFile_openFromFile(sfOutputSoundFile* file, const char* filename, size_t length, DUint channelCount, DUint sampleRate);
 
 //Write samples to a sound file
 DSFML_AUDIO_API void sfOutputSoundFile_write(sfOutputSoundFile* file, const DShort* data, DLong sampleCount);

--- a/include/DSFML/Audio/SoundBuffer.h
+++ b/include/DSFML/Audio/SoundBuffer.h
@@ -39,7 +39,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 
 DSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_construct();
 
-DSFML_AUDIO_API DBool sfSoundBuffer_loadFromFile(sfSoundBuffer* soundBuffer, const char* filename);
+DSFML_AUDIO_API DBool sfSoundBuffer_loadFromFile(sfSoundBuffer* soundBuffer, const char* filename, size_t length);
 
 DSFML_AUDIO_API DBool sfSoundBuffer_loadFromMemory(sfSoundBuffer* soundBuffer, const void* data, size_t sizeInBytes);
 
@@ -51,7 +51,7 @@ DSFML_AUDIO_API sfSoundBuffer* sfSoundBuffer_copy(const sfSoundBuffer* soundBuff
 
 DSFML_AUDIO_API void sfSoundBuffer_destroy(sfSoundBuffer* soundBuffer);
 
-DSFML_AUDIO_API DBool sfSoundBuffer_saveToFile(const sfSoundBuffer* soundBuffer, const char* filename);
+DSFML_AUDIO_API DBool sfSoundBuffer_saveToFile(const sfSoundBuffer* soundBuffer, const char* filename, size_t length);
 
 DSFML_AUDIO_API const DShort* sfSoundBuffer_getSamples(const sfSoundBuffer* soundBuffer);
 

--- a/include/DSFML/Audio/SoundRecorder.h
+++ b/include/DSFML/Audio/SoundRecorder.h
@@ -34,7 +34,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 //Headers
 #include <DSFML/Audio/Export.h>
 #include <DSFML/Audio/SoundRecorderStruct.h>
-
+#include <stddef.h>
 
 DSFML_AUDIO_API sfSoundRecorder* sfSoundRecorder_construct(SoundRecorderCallBacks* newCallBacks);
 
@@ -46,7 +46,7 @@ DSFML_AUDIO_API void sfSoundRecorder_stop(sfSoundRecorder* soundRecorder);
 
 DSFML_AUDIO_API DUint sfSoundRecorder_getSampleRate(const sfSoundRecorder* soundRecorder);
 
-DSFML_AUDIO_API DBool sfSoundRecorder_setDevice (sfSoundRecorder* soundRecorder, const char * name);
+DSFML_AUDIO_API DBool sfSoundRecorder_setDevice (sfSoundRecorder* soundRecorder, const char * name, size_t length);
 
 DSFML_AUDIO_API const char * sfSoundRecorder_getDevice(const sfSoundRecorder* soundRecorder);
 

--- a/include/DSFML/Graphics/Font.h
+++ b/include/DSFML/Graphics/Font.h
@@ -42,7 +42,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 DSFML_GRAPHICS_API sfFont* sfFont_construct(void);
 
 //Load a new font from a file
-DSFML_GRAPHICS_API DBool sfFont_loadFromFile(sfFont* font, const char* filename);
+DSFML_GRAPHICS_API DBool sfFont_loadFromFile(sfFont* font, const char* filename, size_t length);
 
 
 //Load a new image font a file in memory

--- a/include/DSFML/Graphics/Image.h
+++ b/include/DSFML/Graphics/Image.h
@@ -51,7 +51,7 @@ DSFML_GRAPHICS_API void sfImage_createFromColor(sfImage* image, DUint width, DUi
 DSFML_GRAPHICS_API void sfImage_createFromPixels(sfImage* image, DUint width, DUint height, const DUbyte* pixels);
 
 //Create an image from a file on disk
-DSFML_GRAPHICS_API DBool sfImage_loadFromFile(sfImage* image, const char* filename);
+DSFML_GRAPHICS_API DBool sfImage_loadFromFile(sfImage* image, const char* filename, size_t length);
 
 //Create an image from a file in memory
 DSFML_GRAPHICS_API DBool sfImage_loadFromMemory(sfImage* image, const void* data, size_t size);
@@ -66,7 +66,7 @@ DSFML_GRAPHICS_API sfImage* sfImage_copy(const sfImage* image);
 DSFML_GRAPHICS_API void sfImage_destroy(sfImage* image);
 
 //Save an image to a file on disk
-DSFML_GRAPHICS_API DBool sfImage_saveToFile(const sfImage* image, const char* filename);
+DSFML_GRAPHICS_API DBool sfImage_saveToFile(const sfImage* image, const char* filename, size_t length);
 
 //Return the size of an image
 DSFML_GRAPHICS_API void sfImage_getSize(const sfImage* image, DUint* width, DUint* height);

--- a/include/DSFML/Graphics/RenderWindow.h
+++ b/include/DSFML/Graphics/RenderWindow.h
@@ -38,18 +38,19 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Window/VideoMode.h>
 #include <DSFML/Window/WindowHandle.h>
 #include <DSFML/Window/Window.h>
+#include <stddef.h>
 
 //Construct a new render window
 DSFML_GRAPHICS_API sfRenderWindow* sfRenderWindow_construct(void);
 
 //Construct a new render window from settings
-DSFML_GRAPHICS_API sfRenderWindow* sfRenderWindow_constructFromSettings(DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
+DSFML_GRAPHICS_API sfRenderWindow* sfRenderWindow_constructFromSettings(DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
 
 //Construct a render window from an existing control
 DSFML_GRAPHICS_API sfRenderWindow* sfRenderWindow_constructFromHandle(sfWindowHandle handle, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
 
 //Create(or recreate) a new render window from settings
-DSFML_GRAPHICS_API void sfRenderWindow_createFromSettings(sfRenderWindow* renderWindow, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
+DSFML_GRAPHICS_API void sfRenderWindow_createFromSettings(sfRenderWindow* renderWindow, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
 
 //Create(or recreate) a render window from an existing control
 DSFML_GRAPHICS_API void sfRenderWindow_createFromHandle(sfRenderWindow* renderWindow, sfWindowHandle handle, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
@@ -85,10 +86,10 @@ DSFML_GRAPHICS_API void sfRenderWindow_getSize(const sfRenderWindow* renderWindo
 DSFML_GRAPHICS_API void sfRenderWindow_setSize(sfRenderWindow* renderWindow, DInt width, DInt height);
 
 //Change the title of a render window
-DSFML_GRAPHICS_API void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title);
+DSFML_GRAPHICS_API void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title, size_t length);
 
 //Change the title of a render window (with a UTF-32 string)
-DSFML_GRAPHICS_API void sfRenderWindow_setUnicodeTitle(sfRenderWindow* renderWindow, const DUint* title);
+DSFML_GRAPHICS_API void sfRenderWindow_setUnicodeTitle(sfRenderWindow* renderWindow, const DUint* title, size_t length);
 
 //Change a render window's icon
 DSFML_GRAPHICS_API void sfRenderWindow_setIcon(sfRenderWindow* renderWindow, DUint width, DUint height, const DUbyte* pixels);

--- a/include/DSFML/Graphics/Shader.h
+++ b/include/DSFML/Graphics/Shader.h
@@ -36,17 +36,17 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Graphics/Export.h>
 #include <DSFML/Graphics/Types.h>
 #include <DSFML/System/DStream.hpp>
-
+#include <stddef.h>
 
 //Construct a new shader
 DSFML_GRAPHICS_API sfShader* sfShader_construct(void);
 
 //Load both the vertex and fragment shaders from files
-DSFML_GRAPHICS_API DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, const char* fragmentShaderFilename);
+DSFML_GRAPHICS_API DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, size_t vertexShaderFilenameLength, const char* fragmentShaderFilename, size_t fragmentShaderFilenameLength);
 
 
 //Load both the vertex and fragment shaders from source codes in memory
-DSFML_GRAPHICS_API DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, const char* fragmentShader);
+DSFML_GRAPHICS_API DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, size_t vertexShaderLength, const char* fragmentShader, size_t fragmentShaderLength);
 
 
 //Load both the vertex and fragment shaders from custom streams
@@ -58,35 +58,35 @@ DSFML_GRAPHICS_API void sfShader_destroy(sfShader* shader);
 
 
 //Change a float parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setFloatParameter(sfShader* shader, const char* name, float x);
+DSFML_GRAPHICS_API void sfShader_setFloatParameter(sfShader* shader, const char* name, size_t length, float x);
 
 
 //Change a 2-components vector parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setFloat2Parameter(sfShader* shader, const char* name, float x, float y);
+DSFML_GRAPHICS_API void sfShader_setFloat2Parameter(sfShader* shader, const char* name, size_t length, float x, float y);
 
 
 //Change a 3-components vector parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setFloat3Parameter(sfShader* shader, const char* name, float x, float y, float z);
+DSFML_GRAPHICS_API void sfShader_setFloat3Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z);
 
 
 //Change a 4-components vector parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setFloat4Parameter(sfShader* shader, const char* name, float x, float y, float z, float w);
+DSFML_GRAPHICS_API void sfShader_setFloat4Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z, float w);
 
 
 //Change a color parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setColorParameter(sfShader* shader, const char* name, DUbyte r, DUbyte g, DUbyte b, DUbyte a);
+DSFML_GRAPHICS_API void sfShader_setColorParameter(sfShader* shader, const char* name, size_t length, DUbyte r, DUbyte g, DUbyte b, DUbyte a);
 
 
 //Change a matrix parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setTransformParameter(sfShader* shader, const char* name, float* transform);
+DSFML_GRAPHICS_API void sfShader_setTransformParameter(sfShader* shader, const char* name, size_t length, float* transform);
 
 
 //Change a texture parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setTextureParameter(sfShader* shader, const char* name, const sfTexture* texture);
+DSFML_GRAPHICS_API void sfShader_setTextureParameter(sfShader* shader, const char* name, size_t length, const sfTexture* texture);
 
 
 //Change a texture parameter of a shader
-DSFML_GRAPHICS_API void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name);
+DSFML_GRAPHICS_API void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name, size_t length);
 
 
 //Bind a shader for rendering (activate it)

--- a/include/DSFML/Graphics/Texture.h
+++ b/include/DSFML/Graphics/Texture.h
@@ -45,7 +45,7 @@ DSFML_GRAPHICS_API sfTexture* sfTexture_construct(void);
 DSFML_GRAPHICS_API DBool sfTexture_create(sfTexture* texture, DUint width, DUint height);
 
 //Create a new texture from a file
-DSFML_GRAPHICS_API DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, DInt left, DInt top, DInt width, DInt height);
+DSFML_GRAPHICS_API DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, size_t filenameLength, DInt left, DInt top, DInt width, DInt height);
 
 //Create a new texture from a file in memory
 DSFML_GRAPHICS_API DBool sfTexture_loadFromMemory(sfTexture* texture, const void* data, size_t sizeInBytes, DInt left, DInt top, DInt width, DInt height);

--- a/include/DSFML/Network/Ftp.h
+++ b/include/DSFML/Network/Ftp.h
@@ -106,7 +106,7 @@ DSFML_NETWORK_API void sfFtp_destroy(sfFtp* ftp);
 
 
 //Connect to the specified FTP server
-DSFML_NETWORK_API sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, DUshort port, DLong timeout);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, size_t serverIPLength, DUshort port, DLong timeout);
 
 
 //Log in using an anonymous account
@@ -114,7 +114,7 @@ DSFML_NETWORK_API sfFtpResponse* sfFtp_loginAnonymous(sfFtp* ftp);
 
 
 //Log in using a username and a password
-DSFML_NETWORK_API sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, const char* password);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, size_t userNameLength, const char* password, size_t passwordLength);
 
 
 //Close the connection with the server
@@ -130,11 +130,11 @@ DSFML_NETWORK_API sfFtpDirectoryResponse* sfFtp_getWorkingDirectory(sfFtp* ftp);
 
 
 //Get the contents of the given directory
-DSFML_NETWORK_API sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory);
+DSFML_NETWORK_API sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory, size_t length);
 
 
 //Change the current working directory
-DSFML_NETWORK_API sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory, size_t length);
 
 
 //Go to the parent directory of the current one
@@ -142,30 +142,30 @@ DSFML_NETWORK_API sfFtpResponse* sfFtp_parentDirectory(sfFtp* ftp);
 
 
 //Create a new directory
-DSFML_NETWORK_API sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name, size_t length);
 
 
 //Remove an existing directory
-DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name, size_t length);
 
 
 //Rename an existing file
-DSFML_NETWORK_API sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, const char* newName);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, size_t fileLength, const char* newName, size_t newNameLength);
 
 
 //Remove an existing file
-DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name, size_t length);
 
 
 //Download a file from a FTP server
-DSFML_NETWORK_API sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, const char* destPath, DInt mode);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, size_t distantFileLength, const char* destPath, size_t destpathLength, DInt mode);
 
 
 //Upload a file to a FTP server
-DSFML_NETWORK_API sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, const char* destPath, DInt mode);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, size_t localFileLength, const char* destPath, size_t destPathLength, DInt mode);
 
 //Send a command to the FTP server
-DSFML_NETWORK_API sfFtpResponse* sfFtp_sendCommand(sfFtp* ftp, const char* command, const char* parameter);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_sendCommand(sfFtp* ftp, const char* command, size_t commandLength, const char* parameter, size_t parameterLength);
 
 
 #endif // DSFML_FTP_H

--- a/include/DSFML/Network/Http.h
+++ b/include/DSFML/Network/Http.h
@@ -35,11 +35,7 @@ All Libraries used by SFML
 // Headers
 #include <DSFML/Network/Export.h>
 #include <DSFML/Network/Types.h>
-
-
-
-
-
+#include <stddef.h>
 
 ///HTTP Request Functions
 
@@ -52,7 +48,7 @@ DSFML_NETWORK_API void sfHttpRequest_destroy(sfHttpRequest* httpRequest);
 
 
 //Set the value of a header field of a HTTP request
-DSFML_NETWORK_API void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, const char* value);
+DSFML_NETWORK_API void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, size_t fieldLength, const char* value, size_t valueLength);
 
 
 //Set a HTTP request method
@@ -60,7 +56,7 @@ DSFML_NETWORK_API void sfHttpRequest_setMethod(sfHttpRequest* httpRequest, DInt 
 
 
 //Set a HTTP request URI
-DSFML_NETWORK_API void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri);
+DSFML_NETWORK_API void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri, size_t length);
 
 
 //Set the HTTP version of a HTTP request
@@ -68,7 +64,7 @@ DSFML_NETWORK_API void sfHttpRequest_setHttpVersion(sfHttpRequest* httpRequest, 
 
 
 //Set the body of a HTTP request
-DSFML_NETWORK_API void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body);
+DSFML_NETWORK_API void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body, size_t length);
 
 
 ///HTTP Response Functions
@@ -78,7 +74,7 @@ DSFML_NETWORK_API void sfHttpResponse_destroy(sfHttpResponse* httpResponse);
 
 
 //Get the value of a field of a HTTP response
-DSFML_NETWORK_API const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field);
+DSFML_NETWORK_API const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field, size_t fieldlength);
 
 
 //Get the status code of a HTTP reponse
@@ -108,7 +104,7 @@ DSFML_NETWORK_API void sfHttp_destroy(sfHttp* http);
 
 
 //Set the target host of a HTTP object
-DSFML_NETWORK_API void sfHttp_setHost(sfHttp* http, const char* host, DUshort port);
+DSFML_NETWORK_API void sfHttp_setHost(sfHttp* http, const char* host, size_t length,DUshort port);
 
 
 //Send a HTTP request and return the server's response.

--- a/include/DSFML/Network/IpAddress.h
+++ b/include/DSFML/Network/IpAddress.h
@@ -31,10 +31,9 @@ All Libraries used by SFML
 #ifndef DSFML_IPADDRESS_H
 #define DSFML_IPADDRESS_H
 
-
 // Headers
 #include <DSFML/Network/Export.h>
-
+#include <stddef.h>
 
 
 //Note: These functions rely on passing an existing array for the ipAddress.
@@ -42,7 +41,7 @@ All Libraries used by SFML
 
 
 //Create an address from a string
-DSFML_NETWORK_API void sfIpAddress_fromString(const char* address, char* ipAddress);
+DSFML_NETWORK_API void sfIpAddress_fromString(const char* address, size_t addressLength, char* ipAddress);
 
 
 //Create an address from 4 bytes
@@ -54,7 +53,7 @@ DSFML_NETWORK_API void sfIpAddress_fromInteger(DUint address, char* ipAddress);
 
 
 //Get an integer representation of the address
-DSFML_NETWORK_API DUint sfIpAddress_toInteger(const char* ipAddress);
+DSFML_NETWORK_API DUint sfIpAddress_toInteger(const char* ipAddress, size_t length);
 
 
 //Get the computer's local address

--- a/include/DSFML/Window/Joystick.h
+++ b/include/DSFML/Window/Joystick.h
@@ -82,10 +82,13 @@ DSFML_WINDOW_API DBool sfJoystick_isButtonPressed(DUint joystick, DUint button);
 DSFML_WINDOW_API float sfJoystick_getAxisPosition(DUint joystick, DInt axis);
 
 //Get the length of a joystick name for buffer generation
-DSFML_WINDOW_API size_t sfJoystick_getIdentificationNameSize (DUint joystick);
+DSFML_WINDOW_API size_t sfJoystick_getIdentificationNameLength (DUint joystick);
+
+//Write the name of the joystick name to a D-side buffer
+DSFML_WINDOW_API void sfJoystick_getIdentificationName(DUint joystick, DUint * nameBuffer);
 
 //Get the joystick information
-DSFML_WINDOW_API void sfJoystick_getIdentification(DUint joystick, DUint * nameBuffer, DUint * vendorID, DUint* productId);
+DSFML_WINDOW_API void sfJoystick_getIdentification(DUint joystick, DUint * vendorID, DUint* productId);
 
 //Update the states of all joysticks
 DSFML_WINDOW_API void sfJoystick_update(void);

--- a/include/DSFML/Window/Window.h
+++ b/include/DSFML/Window/Window.h
@@ -37,13 +37,14 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Window/Event.h>
 #include <DSFML/Window/WindowHandle.h>
 #include <DSFML/Window/Types.h>
+#include <stddef.h>
 
 //Construct a new window
 DSFML_WINDOW_API sfWindow* sfWindow_construct(void);
 
 
 //Construct a new window from settings
-DSFML_WINDOW_API void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
+DSFML_WINDOW_API void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
 
 
 //Construct a window from an existing control
@@ -91,11 +92,11 @@ DSFML_WINDOW_API void sfWindow_setSize(sfWindow* window, DUint width, DUint heig
 
 
 //Change the title of a window
-DSFML_WINDOW_API void sfWindow_setTitle(sfWindow* window, const char* title);
+DSFML_WINDOW_API void sfWindow_setTitle(sfWindow* window, const char* title, size_t length);
 
 
 //Change the title of a window (with a UTF-32 string)
-DSFML_WINDOW_API void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title);
+DSFML_WINDOW_API void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title, size_t length);
 
 
 //Change a window's icon

--- a/src/DSFML/Audio/InputSoundFile.cpp
+++ b/src/DSFML/Audio/InputSoundFile.cpp
@@ -60,9 +60,9 @@ DUint sfInputSoundFile_getSampleRate(const sfInputSoundFile* file)
     return test;
 }
 
-DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file, const char* filename)
+DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file, const char* filename, size_t length)
 {
-    if(file->This.openFromFile(filename))
+    if(file->This.openFromFile(std::string(filename, length)))
     {
         return DTrue;
     }

--- a/src/DSFML/Audio/OutputSoundFile.cpp
+++ b/src/DSFML/Audio/OutputSoundFile.cpp
@@ -42,9 +42,9 @@ void sfOutputSoundFile_destroy(sfOutputSoundFile* file)
     delete file;
 }
 
-DBool sfOutputSoundFile_openFromFile(sfOutputSoundFile* file, const char* filename,DUint channelCount,DUint sampleRate)
+DBool sfOutputSoundFile_openFromFile(sfOutputSoundFile* file, const char* filename, size_t length, DUint channelCount, DUint sampleRate)
 {
-    bool toReturn = file->This.openFromFile(filename,channelCount,sampleRate);
+    bool toReturn = file->This.openFromFile(std::string(filename, length), channelCount, sampleRate);
 
     return toReturn?DTrue:DFalse;
 }

--- a/src/DSFML/Audio/SoundBuffer.cpp
+++ b/src/DSFML/Audio/SoundBuffer.cpp
@@ -37,9 +37,9 @@ sfSoundBuffer* sfSoundBuffer_construct()
     return new sfSoundBuffer;
 }
 
-DBool sfSoundBuffer_loadFromFile(sfSoundBuffer* soundBuffer, const char* filename)
+DBool sfSoundBuffer_loadFromFile(sfSoundBuffer* soundBuffer, const char* filename, size_t length)
 {
-    return (soundBuffer->This.loadFromFile(filename))?DTrue:DFalse;
+    return (soundBuffer->This.loadFromFile(std::string(filename, length)))?DTrue:DFalse;
 }
 
 DBool sfSoundBuffer_loadFromMemory(sfSoundBuffer* soundBuffer, const void* data, size_t sizeInBytes)
@@ -68,9 +68,9 @@ void sfSoundBuffer_destroy(sfSoundBuffer* soundBuffer)
     delete soundBuffer;
 }
 
-DBool sfSoundBuffer_saveToFile(const sfSoundBuffer* soundBuffer, const char* filename)
+DBool sfSoundBuffer_saveToFile(const sfSoundBuffer* soundBuffer, const char* filename, size_t length)
 {
-    return (soundBuffer->This.saveToFile(filename))? DTrue: DFalse;
+    return (soundBuffer->This.saveToFile(std::string(filename, length)))? DTrue: DFalse;
 }
 
 const DShort* sfSoundBuffer_getSamples(const sfSoundBuffer* soundBuffer)

--- a/src/DSFML/Audio/SoundRecorder.cpp
+++ b/src/DSFML/Audio/SoundRecorder.cpp
@@ -58,9 +58,9 @@ DUint sfSoundRecorder_getSampleRate(const sfSoundRecorder* soundRecorder)
 	return soundRecorder->This.getSampleRate();
 }
 
-DBool sfSoundRecorder_setDevice(sfSoundRecorder* soundRecorder, const char* name)
+DBool sfSoundRecorder_setDevice(sfSoundRecorder* soundRecorder, const char* name, size_t length)
 {
-	return soundRecorder->This.setDevice(name);
+	return soundRecorder->This.setDevice(std::string(name, length));
 }
 
 const char * sfSoundRecorder_getDevice(const sfSoundRecorder* soundRecorder)

--- a/src/DSFML/Graphics/Font.cpp
+++ b/src/DSFML/Graphics/Font.cpp
@@ -38,20 +38,20 @@ sfFont* sfFont_construct()
 {
     sfFont* font = new sfFont;
     font->fontTexture = new sfTexture;
-    
+
     //Delete the internal texture and set OwnInstance to false
     //This will allow us to set the sf::Texture vatiable to the address
     //of the one returned by the font without copying it or destroying it.
     delete font->fontTexture->This;
     font->fontTexture->This = 0;
     font->fontTexture->OwnInstance = false;
-    
+
     return font;
 }
 
-DBool sfFont_loadFromFile(sfFont* font, const char* filename)
+DBool sfFont_loadFromFile(sfFont* font, const char* filename, size_t length)
 {
-    return (font->This.loadFromFile(filename))?DTrue:DFalse;
+    return (font->This.loadFromFile(std::string(filename, length)))?DTrue:DFalse;
 }
 
 

--- a/src/DSFML/Graphics/Image.cpp
+++ b/src/DSFML/Graphics/Image.cpp
@@ -56,9 +56,9 @@ void sfImage_createFromPixels(sfImage* image, DUint width, DUint height, const D
 }
 
 
-DBool sfImage_loadFromFile(sfImage* image, const char* filename)
+DBool sfImage_loadFromFile(sfImage* image, const char* filename, size_t length)
 {
-    return image->This.loadFromFile(filename)?DTrue:DFalse;
+    return image->This.loadFromFile(std::string(filename, length))?DTrue:DFalse;
 }
 
 
@@ -71,7 +71,7 @@ DBool sfImage_loadFromMemory(sfImage* image, const void* data, size_t sizeInByte
 DBool sfImage_loadFromStream(sfImage* image, DStream* stream)
 {
     sfmlStream Stream = sfmlStream(stream);
-    
+
     return image->This.loadFromStream(Stream)?DTrue:DFalse;
 }
 
@@ -89,9 +89,9 @@ void sfImage_destroy(sfImage* image)
 }
 
 
-DBool sfImage_saveToFile(const sfImage* image, const char* filename)
+DBool sfImage_saveToFile(const sfImage* image, const char* filename, size_t length)
 {
-    return image->This.saveToFile(filename)?DTrue:DFalse;
+    return image->This.saveToFile(std::string(filename, length))?DTrue:DFalse;
 }
 
 

--- a/src/DSFML/Graphics/RenderWindow.cpp
+++ b/src/DSFML/Graphics/RenderWindow.cpp
@@ -36,30 +36,31 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Graphics/ImageStruct.h>
 #include <DSFML/Graphics/CreateRenderStates.hpp>
 #include <DSFML/ConvertEvent.h>
+#include <SFML/System/String.hpp>
 
 sfRenderWindow* sfRenderWindow_construct(void)
 {
     return new sfRenderWindow;
 }
 
-sfRenderWindow* sfRenderWindow_constructFromSettings(DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
+sfRenderWindow* sfRenderWindow_constructFromSettings(DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
 {
     // Convert video mode
     sf::VideoMode videoMode(width, height, bitsPerPixel);
 
     // Convert context settings
     sf::ContextSettings params;
-    
+
     params.depthBits         = depthBits;
     params.stencilBits       = stencilBits;
     params.antialiasingLevel = antialiasingLevel;
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
-    
+
 
     // Create the window
     sfRenderWindow* renderWindow = new sfRenderWindow;
-    renderWindow->This.create(videoMode, title, style, params);
+    renderWindow->This.create(videoMode, sf::String(std::basic_string<DUint>(title, titleLength)), style, params);
     renderWindow->DefaultView.This = renderWindow->This.getDefaultView();
     renderWindow->CurrentView.This = renderWindow->This.getView();
 
@@ -70,13 +71,13 @@ sfRenderWindow* sfRenderWindow_constructFromHandle(sfWindowHandle handle, DUint 
 {
     // Convert context settings
     sf::ContextSettings params;
-    
+
     params.depthBits         = depthBits;
     params.stencilBits       = stencilBits;
     params.antialiasingLevel = antialiasingLevel;
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
-    
+
 
     // Create the window
     sfRenderWindow* renderWindow = new sfRenderWindow;
@@ -87,21 +88,21 @@ sfRenderWindow* sfRenderWindow_constructFromHandle(sfWindowHandle handle, DUint 
     return renderWindow;
 }
 
-void sfRenderWindow_createFromSettings(sfRenderWindow* renderWindow, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
+void sfRenderWindow_createFromSettings(sfRenderWindow* renderWindow, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
 {
     // Convert video mode
     sf::VideoMode videoMode(width, height, bitsPerPixel);
 
     // Convert context settings
     sf::ContextSettings params;
-    
+
     params.depthBits         = depthBits;
     params.stencilBits       = stencilBits;
     params.antialiasingLevel = antialiasingLevel;
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
-    
-    renderWindow->This.create(videoMode, title, style, params);
+
+    renderWindow->This.create(videoMode, sf::String(std::basic_string<DUint>(title, titleLength)), style, params);
     renderWindow->DefaultView.This = renderWindow->This.getDefaultView();
     renderWindow->CurrentView.This = renderWindow->This.getView();
 }
@@ -110,13 +111,13 @@ void sfRenderWindow_createFromHandle(sfRenderWindow* renderWindow, sfWindowHandl
 {
     // Convert context settings
     sf::ContextSettings params;
-    
+
     params.depthBits         = depthBits;
     params.stencilBits       = stencilBits;
     params.antialiasingLevel = antialiasingLevel;
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
-    
+
     renderWindow->This.create(handle, params);
     renderWindow->DefaultView.This = renderWindow->This.getDefaultView();
     renderWindow->CurrentView.This = renderWindow->This.getView();
@@ -229,16 +230,16 @@ void sfRenderWindow_setSize(sfRenderWindow* renderWindow, DInt width, DInt heigh
 
 
 
-void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title)
+void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title, size_t length)
 {
-    renderWindow->This.setTitle(title);
+    renderWindow->This.setTitle(std::string(title, length));
 }
 
 
 
-void sfRenderWindow_setUnicodeTitle(sfRenderWindow* renderWindow, const DUint* title)
+void sfRenderWindow_setUnicodeTitle(sfRenderWindow* renderWindow, const DUint* title, size_t length)
 {
-    renderWindow->This.setTitle(title);
+    renderWindow->This.setTitle(sf::String(std::basic_string<DUint>(title, length)));
 }
 
 
@@ -350,7 +351,7 @@ sfView* sfRenderWindow_getDefaultView(const sfRenderWindow* renderWindow)
 
 void sfRenderWindow_getViewport(const sfRenderWindow* renderWindow, const sfView* view, DInt* left, DInt* top, DInt* width, DInt* height)
 {
-    
+
 
     sf::IntRect SFMLrect = renderWindow->This.getViewport(view->This);
     *left   = SFMLrect.left;
@@ -364,7 +365,7 @@ void sfRenderWindow_getViewport(const sfRenderWindow* renderWindow, const sfView
 
 void sfRenderWindow_mapPixelToCoords(const sfRenderWindow* renderWindow, DInt xIn, DInt yIn, float* xOut, float* yOut, const sfView* targetView)
 {
-    
+
 
     sf::Vector2f sfmlPoint;
     if (targetView)
@@ -440,10 +441,10 @@ sfImage* sfRenderWindow_capture(const sfRenderWindow* renderWindow)
 void sfMouse_getPositionRenderWindow(const sfRenderWindow* relativeTo, DInt* x, DInt* y)
 {
     sf::Vector2i sfmlPos;
-   
+
    //Will always be called with a Window
     sfmlPos = sf::Mouse::getPosition(relativeTo->This);
-    
+
     *x = sfmlPos.x;
     *y = sfmlPos.y;
 
@@ -455,5 +456,5 @@ void sfMouse_setPositionRenderWindow(DInt x, DInt y, const sfRenderWindow* relat
 {
     //Will always be called with a Window
     sf::Mouse::setPosition(sf::Vector2i(x, y), relativeTo->This);
-    
+
 }

--- a/src/DSFML/Graphics/Shader.cpp
+++ b/src/DSFML/Graphics/Shader.cpp
@@ -39,26 +39,28 @@ sfShader* sfShader_construct(void)
     return new sfShader;
 }
 
-DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, const char* fragmentShaderFilename)
+DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, size_t vertexShaderFilenameLength,
+							const char* fragmentShaderFilename, size_t fragmentShaderFilenameLength)
 {
     bool success = false;
-    
+
     if (vertexShaderFilename || fragmentShaderFilename)
     {
-        if (!vertexShaderFilename)
+        if (!vertexShaderFilename || vertexShaderFilenameLength < 1)
         {
             // fragment shader only
-            success = shader->This.loadFromFile(fragmentShaderFilename, sf::Shader::Fragment);
+            success = shader->This.loadFromFile(std::string(fragmentShaderFilename, fragmentShaderFilenameLength), sf::Shader::Fragment);
         }
-        else if (!fragmentShaderFilename)
+        else if (!fragmentShaderFilename || fragmentShaderFilenameLength < 1)
         {
             // vertex shader only
-            success = shader->This.loadFromFile(vertexShaderFilename, sf::Shader::Vertex);
+            success = shader->This.loadFromFile(std::string(vertexShaderFilename, vertexShaderFilenameLength), sf::Shader::Vertex);
         }
         else
         {
             // vertex + fragment shaders
-            success = shader->This.loadFromFile(vertexShaderFilename, fragmentShaderFilename);
+            success = shader->This.loadFromFile(std::string(vertexShaderFilename, vertexShaderFilenameLength),
+            			std::string(fragmentShaderFilename, fragmentShaderFilenameLength));
         }
     }
 
@@ -66,26 +68,28 @@ DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, 
 }
 
 
-DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, const char* fragmentShader)
+DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, size_t vertexShaderLength,
+								const char* fragmentShader, size_t fragmentShaderLength)
 {
     bool success = false;
 
     if (vertexShader || fragmentShader)
     {
-        if (!vertexShader)
+        if (!vertexShader || vertexShaderLength < 1)
         {
             // fragment shader only
-            success = shader->This.loadFromMemory(fragmentShader, sf::Shader::Fragment);
+            success = shader->This.loadFromMemory(std::string(fragmentShader, fragmentShaderLength), sf::Shader::Fragment);
         }
-        else if (!fragmentShader)
+        else if (!fragmentShader || fragmentShaderLength < 1)
         {
             // vertex shader only
-            success = shader->This.loadFromMemory(vertexShader, sf::Shader::Vertex);
+            success = shader->This.loadFromMemory(std::string(vertexShader, vertexShaderLength), sf::Shader::Vertex);
         }
         else
         {
             // vertex + fragment shaders
-            success = shader->This.loadFromMemory(vertexShader, fragmentShader);
+            success = shader->This.loadFromMemory(std::string(vertexShader, vertexShaderLength),
+            										std::string(fragmentShader, fragmentShaderLength));
         }
     }
 
@@ -96,7 +100,7 @@ DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, const 
 DBool sfShader_loadFromStream(sfShader* shader, DStream* vertexShaderStream, DStream* fragmentShaderStream)
 {
     bool success = false;
-    
+
     if (vertexShaderStream || fragmentShaderStream)
     {
         if (!vertexShaderStream)
@@ -130,51 +134,51 @@ void sfShader_destroy(sfShader* shader)
 }
 
 
-void sfShader_setFloatParameter(sfShader* shader, const char* name, float x)
+void sfShader_setFloatParameter(sfShader* shader, const char* name, size_t length , float x)
 {
-    shader->This.setParameter(name, x);
+    shader->This.setParameter(std::string(name, length), x);
 }
 
 
-void sfShader_setFloat2Parameter(sfShader* shader, const char* name, float x, float y)
+void sfShader_setFloat2Parameter(sfShader* shader, const char* name, size_t length, float x, float y)
 {
-    shader->This.setParameter(name, x, y);
+    shader->This.setParameter(std::string(name, length), x, y);
 }
 
 
-void sfShader_setFloat3Parameter(sfShader* shader, const char* name, float x, float y, float z)
+void sfShader_setFloat3Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z)
 {
-    shader->This.setParameter(name, x, y, z);
+    shader->This.setParameter(std::string(name, length), x, y, z);
 }
 
 
-void sfShader_setFloat4Parameter(sfShader* shader, const char* name, float x, float y, float z, float w)
+void sfShader_setFloat4Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z, float w)
 {
-    shader->This.setParameter(name, x, y, z, w);
+    shader->This.setParameter(std::string(name, length), x, y, z, w);
 }
 
 
-void sfShader_setColorParameter(sfShader* shader, const char* name, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
+void sfShader_setColorParameter(sfShader* shader, const char* name, size_t length, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
 {
-    shader->This.setParameter(name, sf::Color(r, g, b, a));
+    shader->This.setParameter(std::string(name, length), sf::Color(r, g, b, a));
 }
 
 
-void sfShader_setTransformParameter(sfShader* shader, const char* name, float* transform)
+void sfShader_setTransformParameter(sfShader* shader, const char* name, size_t length, float* transform)
 {
-    shader->This.setParameter(name, createTransform(transform));
+    shader->This.setParameter(std::string(name, length), createTransform(transform));
 }
 
 
-void sfShader_setTextureParameter(sfShader* shader, const char* name, const sfTexture* texture)
+void sfShader_setTextureParameter(sfShader* shader, const char* name, size_t length, const sfTexture* texture)
 {
-    shader->This.setParameter(name, *texture->This);
+    shader->This.setParameter(std::string(name, length), *texture->This);
 }
 
 
-void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name)
+void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name, size_t length)
 {
-    shader->This.setParameter(name, sf::Shader::CurrentTexture);
+    shader->This.setParameter(std::string(name, length), sf::Shader::CurrentTexture);
 }
 
 

--- a/src/DSFML/Graphics/Texture.cpp
+++ b/src/DSFML/Graphics/Texture.cpp
@@ -43,17 +43,17 @@ sfTexture* sfTexture_construct(void)
 
 
 DBool sfTexture_create(sfTexture* texture, DUint width, DUint height)
-{ 
+{
     return texture->This->create(width, height)?DTrue:DFalse;
 
 }
 
 
-DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, DInt left, DInt top, DInt width, DInt height)
+DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, size_t filenameLength, DInt left, DInt top, DInt width, DInt height)
 {
     sf::IntRect rect = sf::IntRect(left, top, width, height);
 
-    return texture->This->loadFromFile(filename, rect)?DTrue:DFalse;
+    return texture->This->loadFromFile(std::string(filename, filenameLength), rect)?DTrue:DFalse;
 }
 
 

--- a/src/DSFML/Network/Ftp.cpp
+++ b/src/DSFML/Network/Ftp.cpp
@@ -128,9 +128,9 @@ void sfFtp_destroy(sfFtp* ftp)
 }
 
 
-sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, DUshort port, DLong timeout)
+sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, size_t length, DUshort port, DLong timeout)
 {
-    sf::IpAddress SFMLServer(serverIP);
+    sf::IpAddress SFMLServer(std::string(serverIP, length));
 
     return new sfFtpResponse(ftp->This.connect(SFMLServer, port, sf::microseconds(timeout)));
 }
@@ -142,9 +142,9 @@ sfFtpResponse* sfFtp_loginAnonymous(sfFtp* ftp)
 }
 
 
-sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, const char* password)
+sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, size_t userNameLength, const char* password, size_t passwordLength)
 {
-    return new sfFtpResponse(ftp->This.login(userName ? userName : "", password ? password : ""));
+    return new sfFtpResponse(ftp->This.login(userName ? std::string(userName, userNameLength) : "", password ? std::string(password, passwordLength) : ""));
 }
 
 
@@ -166,15 +166,15 @@ sfFtpDirectoryResponse* sfFtp_getWorkingDirectory(sfFtp* ftp)
 }
 
 
-sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory)
+sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory, size_t length)
 {
-    return new sfFtpListingResponse(ftp->This.getDirectoryListing(directory ? directory : ""));
+    return new sfFtpListingResponse(ftp->This.getDirectoryListing(directory ? std::string(directory, length) : ""));
 }
 
 
-sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory)
+sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory, size_t length)
 {
-    return new sfFtpResponse(ftp->This.changeDirectory(directory ? directory : ""));
+    return new sfFtpResponse(ftp->This.changeDirectory(directory ? std::string(directory, length) : ""));
 }
 
 
@@ -184,47 +184,47 @@ sfFtpResponse* sfFtp_parentDirectory(sfFtp* ftp)
 }
 
 
-sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name)
+sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name, size_t length)
 {
-    return new sfFtpResponse(ftp->This.createDirectory(name ? name : ""));
+    return new sfFtpResponse(ftp->This.createDirectory(name ? std::string(name, length) : ""));
 }
 
 
-sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name)
+sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name, size_t length)
 {
-    return new sfFtpResponse(ftp->This.deleteDirectory(name ? name : ""));
+    return new sfFtpResponse(ftp->This.deleteDirectory(name ? std::string(name, length) : ""));
 }
 
 
-sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, const char* newName)
+sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, size_t fileLength, const char* newName, size_t newNameLength)
 {
-    return new sfFtpResponse(ftp->This.renameFile(file ? file : "", newName ? newName : ""));
+    return new sfFtpResponse(ftp->This.renameFile(file ? std::string(file, fileLength) : "", newName ? std::string(newName, newNameLength) : ""));
 }
 
 
-sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name)
+sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name, size_t length)
 {
-    return new sfFtpResponse(ftp->This.deleteFile(name ? name : ""));
+    return new sfFtpResponse(ftp->This.deleteFile(name ? std::string(name, length) : ""));
 }
 
 
-sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, const char* destPath, DInt mode)
+sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, size_t distantFileLength, const char* destPath, size_t destPathLength, DInt mode)
 {
-    return new sfFtpResponse(ftp->This.download(distantFile ? distantFile : "",
-                                                destPath ? destPath : "",
+    return new sfFtpResponse(ftp->This.download(distantFile ? std::string(distantFile, distantFileLength) : "",
+                                                destPath ? std::string(destPath, destPathLength) : "",
                                                 static_cast<sf::Ftp::TransferMode>(mode)));
 }
 
 
-sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, const char* destPath, DInt mode)
+sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, size_t localFileLength, const char* destPath, size_t destPathLength, DInt mode)
 {
-    return new sfFtpResponse(ftp->This.upload(localFile ? localFile : "",
-                                              destPath ? destPath : "",
+    return new sfFtpResponse(ftp->This.upload(localFile ? std::string(localFile, localFileLength) : "",
+                                              destPath ? std::string(destPath, destPathLength) : "",
                                               static_cast<sf::Ftp::TransferMode>(mode)));
 }
 
-sfFtpResponse* sfFtp_sendCommand(sfFtp* ftp, const char* command, const char* parameter)
+sfFtpResponse* sfFtp_sendCommand(sfFtp* ftp, const char* command, size_t commandLength, const char* parameter, size_t parameterLength)
 {
-    return new sfFtpResponse(ftp->This.sendCommand(command ? command : "",
-                                              parameter ? parameter : ""));
+    return new sfFtpResponse(ftp->This.sendCommand(command ? std::string(command, commandLength) : "",
+                                              parameter ? std::string(parameter, parameterLength) : ""));
 }

--- a/src/DSFML/Network/Http.cpp
+++ b/src/DSFML/Network/Http.cpp
@@ -49,10 +49,10 @@ void sfHttpRequest_destroy(sfHttpRequest* httpRequest)
 
 
 
-void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, const char* value)
+void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, size_t fieldLength, const char* value, size_t valueLength)
 {
     if (field)
-        httpRequest->This.setField(field, value);
+        httpRequest->This.setField(std::string(field, fieldLength), std::string(value, valueLength));
 }
 
 
@@ -64,9 +64,9 @@ void sfHttpRequest_setMethod(sfHttpRequest* httpRequest, DInt method)
 
 
 
-void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri)
+void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri, size_t length)
 {
-    httpRequest->This.setUri(uri ? uri : "");
+    httpRequest->This.setUri(uri ? std::string(uri, length) : "");
 }
 
 
@@ -78,9 +78,9 @@ void sfHttpRequest_setHttpVersion(sfHttpRequest* httpRequest, DUint major, DUint
 
 
 
-void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body)
+void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body, size_t length)
 {
-    httpRequest->This.setBody(body ? body : "");
+    httpRequest->This.setBody(body ? std::string(body, length) : "");
 }
 
 
@@ -92,12 +92,12 @@ void sfHttpResponse_destroy(sfHttpResponse* httpResponse)
 }
 
 
-const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field)
+const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field, size_t length)
 {
     if (!field)
         return NULL;
 
-    return httpResponse->This.getField(field).c_str();
+    return httpResponse->This.getField(std::string(field, length)).c_str();
 }
 
 
@@ -145,9 +145,9 @@ void sfHttp_destroy(sfHttp* http)
 
 
 
-void sfHttp_setHost(sfHttp* http, const char* host, DUshort port)
+void sfHttp_setHost(sfHttp* http, const char* host, size_t length, DUshort port)
 {
-    http->This.setHost(host ? host : "", port);
+    http->This.setHost(host ? std::string(host, length) : "", port);
 }
 
 

--- a/src/DSFML/Network/IpAddress.cpp
+++ b/src/DSFML/Network/IpAddress.cpp
@@ -43,16 +43,16 @@ namespace
     }
 
     // Helper function for converting an array address to a SFML one
-    sf::IpAddress toSFMLAddress(const char* ipAddress)
+    sf::IpAddress toSFMLAddress(const char* ipAddress, size_t length)
     {
-        return sf::IpAddress(ipAddress);
+        return sf::IpAddress(std::string(ipAddress, length));
     }
 }
 
 
-void sfIpAddress_fromString(const char* address, char* ipAddress)
+void sfIpAddress_fromString(const char* address, size_t addressLength, char* ipAddress)
 {
-    fromSFMLAddress(sf::IpAddress(address), ipAddress);
+    fromSFMLAddress(sf::IpAddress(std::string(address, addressLength)), ipAddress);
 }
 
 
@@ -68,9 +68,9 @@ void sfIpAddress_fromInteger(DUint address, char* ipAddress)
 }
 
 
-DUint sfIpAddress_toInteger(const char* ipAddress)
+DUint sfIpAddress_toInteger(const char* ipAddress, size_t length)
 {
-    return toSFMLAddress(ipAddress).toInteger();
+    return toSFMLAddress(ipAddress, length).toInteger();
 }
 
 

--- a/src/DSFML/Window/Joystick.cpp
+++ b/src/DSFML/Window/Joystick.cpp
@@ -68,26 +68,27 @@ float sfJoystick_getAxisPosition(DUint joystick, DInt axis)
     return sf::Joystick::getAxisPosition(joystick, static_cast<sf::Joystick::Axis>(axis));
 }
 
-size_t sfJoystick_getIdentificationNameSize (DUint joystick)
+size_t sfJoystick_getIdentificationNameLength (DUint joystick)
 {
 	return sf::Joystick::getIdentification(joystick).name.getSize();
 }
 
-void sfJoystick_getIdentification(DUint joystick, DUint * nameBuffer, DUint * vendorId, DUint* productId)
+void sfJoystick_getIdentificationName (DUint joystick, DUint * nameBuffer)
 {
+	//On Linux, just returning the pointer to the name string works fine, but on windows it corrupts during passing.
 	sf::Joystick::Identification sfmlIdentification = sf::Joystick::getIdentification(joystick);
 
-	//XXX Is this the right way to pass a sf::String to D?
-	//*name = sfmlIdentification.name.toUtf32().c_str();
-	//XXX Or is this? SFML documentation says this is for immediate-use data but we'll likely need to make a copy it on the D-side anyway.
-	//*name = sfmlIdentification.name.getData();
-	//*nameSize = sfmlIdentification.name.getSize();
-
-	//XXX WE HATES THIS, PRECIOUS, WE HATES IT
 	for (unsigned int i = 0; i < sfmlIdentification.name.getSize(); i++)
 	{
 		nameBuffer[i] = sfmlIdentification.name[i];
 	}
+
+}
+
+void sfJoystick_getIdentification(DUint joystick, DUint * vendorId, DUint* productId)
+{
+	sf::Joystick::Identification sfmlIdentification = sf::Joystick::getIdentification(joystick);
+
 	*vendorId = sfmlIdentification.vendorId;
 	*productId = sfmlIdentification.productId;
 }

--- a/src/DSFML/Window/Window.cpp
+++ b/src/DSFML/Window/Window.cpp
@@ -32,6 +32,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFML/Window/Window.h>
 #include <DSFML/Window/WindowStruct.h>
 #include <DSFML/ConvertEvent.h>
+#include <SFML/System/String.hpp>
 
 
 sfWindow* sfWindow_construct(void)
@@ -39,7 +40,7 @@ sfWindow* sfWindow_construct(void)
     return new sfWindow;
 }
 
-void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
+void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
 {
     // Convert video mode
     sf::VideoMode videoMode(width, height, bitsPerPixel);
@@ -54,7 +55,7 @@ void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DU
         params.minorVersion      = minorVersion;
 
 
-    window->This.create(videoMode, title, style, params);
+    window->This.create(videoMode, sf::String(std::basic_string<DUint>(title, titleLength)), style, params);
 }
 
 void sfWindow_createFromHandle(sfWindow* window, sfWindowHandle handle, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion)
@@ -176,9 +177,9 @@ void sfWindow_setTitle(sfWindow* window, const char* title)
 }
 
 
-void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title)
+void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title, size_t length)
 {
-    window->This.setTitle(title);
+    window->This.setTitle(std::basic_string<DUint>(title, length));
 }
 
 


### PR DESCRIPTION
Here's the DSFMLC side of the patch that gets rid of allocations when passing string data from the D-side. I'm not incredibly familiar with C++, so I hope just having the std::string() constructors in the call statements isn't bad behavior. 

The converse--minimizing or eliminating allocations when passing strings from C++ to D--is beyond my knowledge of C++ and D's underlying memory details; We might be able to do something once D's C++ interop is good enough to handle std::strings.

I've also made a minor change to the way Joystick identification is passed to avoid extraneous allocations D-side.

c.f. https://github.com/Jebbs/DSFML/issues/225
